### PR TITLE
Properly include joda-convert in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ public class MyApp extends Application {
 }
 ```
 
+Known Issues
+============
+
+If you are using versions of the Android Gradle plugin previous to 1.3, you may need to exclude some files for
+packaging to work properly:
+
+```groovy
+android {
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/NOTICE.txt'
+    }
+}
+```
+
 Updating the TimeZone database
 ==============================
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,10 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:1.3.0-beta1'
     }
 }
 
 apply plugin: 'android-reporting'
-

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 22
@@ -16,6 +16,11 @@ android {
     lintOptions {
         lintConfig file('lint.xml')
     }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/NOTICE.txt'
+    }
 }
 
 apply from: 'gradle-mvn-push.gradle'
@@ -30,6 +35,7 @@ configurations {
 
 dependencies {
     compile 'joda-time:joda-time:2.8:no-tzdb'
+    compile 'org.joda:joda-convert:1.2'
     updateTzData 'joda-time:joda-time:2.8'
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 22
@@ -9,6 +9,16 @@ android {
         versionName '1.0'
         minSdkVersion 9
         targetSdkVersion 22
+
+        proguardFiles getDefaultProguardFile('proguard-android.txt')
+    }
+
+    // We're enabling proguard just to prove we don't have to do anything
+    // special to get this build to work with proguard.
+    buildTypes {
+        debug {
+            minifyEnabled true
+        }
     }
 }
 


### PR DESCRIPTION
This prevents a lot of proguard build warnings, as we were not
including a dependency that joda-time was using.

Had to update to the latest build plugin, too; otherwise we can't
exclude packaging files that will cause pain down the line.

Addresses #36 by getting rid of the need for any custom proguarding.