### PR TITLE
Shorten resource prefix to "joda_"

### DIFF
--- a/buildSrc/src/main/groovy/net/danlew/android/joda/TzDataPlugin.groovy
+++ b/buildSrc/src/main/groovy/net/danlew/android/joda/TzDataPlugin.groovy
@@ -103,10 +103,10 @@ class TzDataPlugin implements Plugin<Project> {
         city = city.toLowerCase().replace('+', 'plus').replace('-', '_')
         if (region) {
             region = region.toLowerCase().replace('/', '_')
-            'joda_time_android_tzdata_' + region + '_' + city
+            'joda_' + region + '_' + city
         }
         else {
-            'joda_time_android_tzdata_' + city
+            'joda_' + city
         }
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 22
     buildToolsVersion '22.0.1'
-    resourcePrefix 'joda_time_android_'
+    resourcePrefix 'joda_'
 
     defaultConfig {
         consumerProguardFiles 'proguard-rules.txt'

--- a/library/src/main/java/net/danlew/android/joda/ResUtils.java
+++ b/library/src/main/java/net/danlew/android/joda/ResUtils.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ResUtils {
 
-    private static final String TZDATA_PREFIX = "joda_time_android_tzdata_";
+    private static final String TZDATA_PREFIX = "joda_";
 
     /**
      * Converts any path into something that can be placed in an Android directory.


### PR DESCRIPTION
It looks like some OSes were having problems finding resources with such long
paths.