### PR TITLE
Keep tzdata with shrinkResources

### DIFF
--- a/library/src/main/res/raw/joda_keep.xml
+++ b/library/src/main/res/raw/joda_keep.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Timezone data are lazy-loaded by reflection, so we have to explicitly
+    keep shrinkResources from removing any of them.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools"
+           tools:keep="@raw/joda_*" />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,6 +18,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled true
+            shrinkResources true
         }
     }
 }


### PR DESCRIPTION
Otherwise it all gets removed (since it's retrieved by reflection)
and that means the lib itself just won't work at all.

Fixes #100 