### PR TITLE
Updated joda-time dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    compile 'joda-time:joda-time:2.9.3:no-tzdb'
+    compile 'joda-time:joda-time:2.9.4:no-tzdb'
 }
 
 tzdata {


### PR DESCRIPTION
Joda Time v2.9.4 was [released](https://github.com/JodaOrg/joda-time/releases/tag/v2.9.4) 24 days ago.
This PR only updates the joda time dependency.