### PR TITLE
squid:HiddenFieldCheck - Local variables should not shadow class fields

### DIFF
--- a/library/src/androidTest/java/net/danlew/android/joda/test/TestDateTimeZone.java
+++ b/library/src/androidTest/java/net/danlew/android/joda/test/TestDateTimeZone.java
@@ -143,7 +143,7 @@ public class TestDateTimeZone extends InstrumentationTestCase {
         };
     }
     
-    private DateTimeZone zone;
+    private DateTimeZone defaultZone;
     private Locale locale;
 
     protected void setUp() throws Exception {
@@ -155,13 +155,13 @@ public class TestDateTimeZone extends InstrumentationTestCase {
         LONDON = DateTimeZone.forID("Europe/London");
 
         locale = Locale.getDefault();
-        zone = DateTimeZone.getDefault();
+        defaultZone = DateTimeZone.getDefault();
         Locale.setDefault(Locale.UK);
     }
 
     protected void tearDown() throws Exception {
         Locale.setDefault(locale);
-        DateTimeZone.setDefault(zone);
+        DateTimeZone.setDefault(defaultZone);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:HiddenFieldCheck - Local variables should not shadow class fields

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck

Please let me know if you have any questions.
Soso Tughushi