### PR TITLE
General code fix 2

### DIFF
--- a/library/src/androidTest/java/net/danlew/android/joda/test/TestDateTimeZone.java
+++ b/library/src/androidTest/java/net/danlew/android/joda/test/TestDateTimeZone.java
@@ -62,6 +62,7 @@ import java.util.TimeZone;
  */
 public class TestDateTimeZone extends InstrumentationTestCase {
     private static final boolean OLD_JDK;
+    private static final boolean JDK6;
     static {
         String str = System.getProperty("java.version");
         boolean old = true;
@@ -82,23 +83,23 @@ public class TestDateTimeZone extends InstrumentationTestCase {
     // no longer final
     private static DateTimeZone PARIS;
     private static DateTimeZone LONDON;
-    
-    long y2002days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 
+
+    private static final long Y_2002_DAYS = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 
                      365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365;
-    long y2003days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 
+    private static final long Y_2003_DAYS = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 
                      365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365 + 365;
     
     // 2002-06-09
-    private long TEST_TIME_SUMMER =
-            (y2002days + 31L + 28L + 31L + 30L + 31L + 9L -1L) * DateTimeConstants.MILLIS_PER_DAY;
+    private static final long TEST_TIME_SUMMER =
+            (Y_2002_DAYS + 31L + 28L + 31L + 30L + 31L + 9L -1L) * DateTimeConstants.MILLIS_PER_DAY;
             
     // 2002-01-09
     private long TEST_TIME_WINTER =
-            (y2002days + 9L -1L) * DateTimeConstants.MILLIS_PER_DAY;
+            (Y_2002_DAYS + 9L -1L) * DateTimeConstants.MILLIS_PER_DAY;
             
 //    // 2002-04-05 Fri
 //    private long TEST_TIME1 =
@@ -117,13 +118,16 @@ public class TestDateTimeZone extends InstrumentationTestCase {
     static {
         // don't call Policy.getPolicy()
         RESTRICT = new Policy() {
+            @Override
             public PermissionCollection getPermissions(CodeSource codesource) {
                 Permissions p = new Permissions();
                 p.add(new AllPermission());  // enable everything
                 return p;
             }
+            @Override
             public void refresh() {
             }
+            @Override
             public boolean implies(ProtectionDomain domain, Permission permission) {
                 if (permission instanceof JodaTimePermission) {
                     return false;
@@ -133,11 +137,13 @@ public class TestDateTimeZone extends InstrumentationTestCase {
             }
         };
         ALLOW = new Policy() {
+            @Override
             public PermissionCollection getPermissions(CodeSource codesource) {
                 Permissions p = new Permissions();
                 p.add(new AllPermission());  // enable everything
                 return p;
             }
+            @Override
             public void refresh() {
             }
         };
@@ -397,11 +403,11 @@ public class TestDateTimeZone extends InstrumentationTestCase {
         
         zone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT-02:00"));
         assertEquals("-02:00", zone.getID());
-        assertEquals((-2L * DateTimeConstants.MILLIS_PER_HOUR), zone.getOffset(TEST_TIME_SUMMER));
+        assertEquals(-2L * DateTimeConstants.MILLIS_PER_HOUR, zone.getOffset(TEST_TIME_SUMMER));
         
         zone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT+2"));
         assertEquals("+02:00", zone.getID());
-        assertEquals((2L * DateTimeConstants.MILLIS_PER_HOUR), zone.getOffset(TEST_TIME_SUMMER));
+        assertEquals(2L * DateTimeConstants.MILLIS_PER_HOUR, zone.getOffset(TEST_TIME_SUMMER));
         
         zone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("EST"));
         assertEquals("America/New_York", zone.getID());
@@ -656,8 +662,6 @@ public class TestDateTimeZone extends InstrumentationTestCase {
         assertEquals("BST", zone.getNameKey(TEST_TIME_SUMMER));
         assertEquals("GMT", zone.getNameKey(TEST_TIME_WINTER));
     }
-
-    static final boolean JDK6;
     static {
       boolean jdk6 = true;
       try {

--- a/library/src/main/java/net/danlew/android/joda/ResUtils.java
+++ b/library/src/main/java/net/danlew/android/joda/ResUtils.java
@@ -18,6 +18,9 @@ public class ResUtils {
 
     private static final String TZDATA_PREFIX = "joda_";
 
+    /** Cache of resources ids, for speed */
+    private static Map<Class<?>, Map<String, Integer>> sIdentifierCache = new ConcurrentHashMap<Class<?>, Map<String, Integer>>();
+
     /**
      * Converts any path into something that can be placed in an Android directory.
      *
@@ -66,9 +69,6 @@ public class ResUtils {
     public static String getZoneInfoMapResource() {
         return TZDATA_PREFIX + convertPathToResource("ZoneInfoMap");
     }
-
-    /** Cache of resources ids, for speed */
-    private static Map<Class<?>, Map<String, Integer>> sIdentifierCache = new ConcurrentHashMap<Class<?>, Map<String, Integer>>();
 
     /**
      * Retrieves a resource id dynamically, via reflection.  It's much faster

--- a/library/src/main/java/net/danlew/android/joda/ResourceZoneInfoProvider.java
+++ b/library/src/main/java/net/danlew/android/joda/ResourceZoneInfoProvider.java
@@ -116,9 +116,7 @@ public class ResourceZoneInfoProvider implements Provider {
             throw new IOException("Resource not found: \"" + name + "\" (resName: \"" + resName + "\")");
         }
 
-        InputStream in = mAppContext.getResources().openRawResource(resId);
-
-        return in;
+        return mAppContext.getResources().openRawResource(resId);
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S00116 - Field names should comply with a naming convention
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.


You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1161
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S00116
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213
https://dev.eclipse.org/sonar/coding_rules#q=S1488

Please let me know if you have any questions.
Soso Tughushi