### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/library/src/main/java/net/danlew/android/joda/DateUtils.java
+++ b/library/src/main/java/net/danlew/android/joda/DateUtils.java
@@ -38,6 +38,8 @@ import org.joda.time.Years;
  */
 public class DateUtils {
 
+    private DateUtils(){}
+
     // The following FORMAT_* symbols are used for specifying the format of
     // dates and times in the formatDateRange method.
     public static final int FORMAT_SHOW_TIME = android.text.format.DateUtils.FORMAT_SHOW_TIME;

--- a/library/src/main/java/net/danlew/android/joda/ResUtils.java
+++ b/library/src/main/java/net/danlew/android/joda/ResUtils.java
@@ -16,6 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ResUtils {
 
+    private ResUtils(){}
+
     private static final String TZDATA_PREFIX = "joda_";
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.
Soso Tughushi