### PR TITLE
Update to joda-time 2.9.6

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    compile 'joda-time:joda-time:2.9.5:no-tzdb'
+    compile 'joda-time:joda-time:2.9.6:no-tzdb'
 }
 
 tzdata {


### PR DESCRIPTION
Fixes #137 (though you can also just include the dependency manually as a workaround until this change is released).