### PR TITLE
Update README to use pickFirst over exclude.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,28 @@ or
 
 > Duplicate files copied in APK META-INF/NOTICE.txt
 
-__A: We can safely choose to only pick the first ones of thoses files from our build. You need to specify these two `pickFirst`s in your `build.gradle` file and you will be good to go:__
+__A: We can safely exclude thoses files from our build. You need to specify these two `exclude`s in your `build.gradle` file and you will be good to go:__
 
 ```
 android {
     ...
     packagingOptions {
-        pickFirst 'META-INF/LICENSE.txt'
-        pickFirst 'META-INF/NOTICE.txt'
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/NOTICE.txt'
+    }
+}
+```
+
+or 
+
+__B: We can safely choose to add those files to our build. You need to specify these two `merge`s in your `build.gradle` file and you will be good to go:__
+
+```
+android {
+    ...
+    packagingOptions {
+        merge '**/LICENSE.txt'
+        merge '**/NOTICE.txt'
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ or
 
 > Duplicate files copied in APK META-INF/NOTICE.txt
 
-__A: We can safely exclude thoses files from our build. You need to specify these two `exclude`s in your `build.gradle` file and you will be good to go:__
+__A: We can safely choose to only pick the first ones of thoses files from our build. You need to specify these two `pickFirst`s in your `build.gradle` file and you will be good to go:__
 
 ```
 android {
     ...
     packagingOptions {
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
+        pickFirst 'META-INF/LICENSE.txt'
+        pickFirst 'META-INF/NOTICE.txt'
     }
 }
 ```


### PR DESCRIPTION
It’s good practice to include the licenses/notices in the build because those are important and most likely a part of the licenses.

Using `pickFirst` will pick only the first one, thus removing the “duplicate files....” error, while also following the licenses requirements.