### PR TITLE
Added JodaTimeAndroid.TZ_DATA_VERSION

### DIFF
--- a/library/src/main/java/net/danlew/android/joda/JodaTimeAndroid.java
+++ b/library/src/main/java/net/danlew/android/joda/JodaTimeAndroid.java
@@ -15,6 +15,8 @@ import java.io.IOException;
  */
 public final class JodaTimeAndroid {
 
+    public static String TZ_DATA_VERSION = "2020a";
+
     /** Whether the JodaTimeAndroid.init() method has been called. */
     private static boolean sInitCalled = false;
 


### PR DESCRIPTION
Allows people to query which version of the tzdata the library is
equipped with.

Fixes #242. (Also worth noting this PR works in concert with #249, which updates us to 2020a.)