### PR TITLE
Ensure we keep all R.raw resources

### DIFF
--- a/library/proguard-rules.txt
+++ b/library/proguard-rules.txt
@@ -1,3 +1,6 @@
+# All the resources are retrieved via reflection, so we need to make sure we keep them
+-keep class net.danlew.android.joda.R$raw { *; }
+
 # These aren't necessary if including joda-convert, but
 # most people aren't, so it's helpful to include it.
 -dontwarn org.joda.convert.FromString


### PR DESCRIPTION
That's where all the tzdata goes, so you're going to want that if
you're using joda-time-android.

Fixes #206 