### PR TITLE
Scope ProGuard rules to library

### DIFF
--- a/library/proguard-rules.txt
+++ b/library/proguard-rules.txt
@@ -9,8 +9,8 @@
 # Joda classes use the writeObject special method for Serializable, so
 # if it's stripped, we'll run into NotSerializableExceptions.
 # https://www.guardsquare.com/en/products/proguard/manual/examples#serializable
--keepnames class * implements java.io.Serializable
--keepclassmembers class * implements java.io.Serializable {
+-keepnames class org.joda.** implements java.io.Serializable
+-keepclassmembers class org.joda.** implements java.io.Serializable {
     static final long serialVersionUID;
     private static final java.io.ObjectStreamField[] serialPersistentFields;
     !static !transient <fields>;


### PR DESCRIPTION
ProGuard rules are really easy to add from different libraries, but they are hard to exclude from a subset of libraries. I'd suggest scope all rules under the Joda namespace, to avoid collisions with other libraries / main packages.

We are stuck with version 2.10.6 because of the insertion of these rules. When keeping the names of everything that implements Serializable (directly or indirectly), a good portion of the code (especially when using Kotlin / Kotlin Serialization) is not obfuscated, despite it being able to run correctly without the rules.
Scoping the rules to the library only, not only makes sense from a packaging perspective, but also allows for better control over what need Serialization and what doesn't.

I've also found out that we do not need the name of the classes to be kept, Joda works correctly without them, because serialization appears to be used only in live environment where the class is renamed but constant.
Better testing might be needed here, but I can't find a point where it differs.
If we want to keep the class name as well, I'd suggest we scope it under the Joda namespace too.

This leads to both more obfuscation and lower bundle size.
Let me know if you need more details on this.