### PR TITLE
Fixed artifact selector for joda-time no-tzdb

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     api(libs.jodaTime) {
         artifact {
             classifier = "no-tzdb"
+            extension = "jar"
         }
     }
 


### PR DESCRIPTION
Without this, the Gradle module.json would lead Gradle astray (causing it to
look for a folder "no-tzdb" instead of a jar).

Fixes #312